### PR TITLE
Bump versions in nix flake

### DIFF
--- a/.nix/flake.nix
+++ b/.nix/flake.nix
@@ -14,9 +14,9 @@
         devShells = {
             default = pkgs.mkShell {
               buildInputs = with pkgs; [
-                python311Packages.requests
-                python311Packages.beautifulsoup4
-                python311Packages.hatchling
+                python313Packages.requests
+                python313Packages.beautifulsoup4
+                python313Packages.hatchling
               ];
           };
         };
@@ -26,8 +26,8 @@
             name = "SpecMerger";
             src = ./..;
             propagatedBuildInputs = with pkgs; [
-              python311
-              python311Packages.hatchling
+              python313
+              python313Packages.hatchling
             ];
             format = "pyproject";
           };

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764242076,
+        "narHash": "sha256-sKoIWfnijJ0+9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2fad6eac6077f03fe109c4d4eb171cf96791faa4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "spec-merger": "spec-merger"
+      }
+    },
+    "spec-merger": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "dir": ".nix",
+        "lastModified": 1744998158,
+        "narHash": "sha256-INH13MG/ty45xl7ppg6d3AelIZMPX34pTX7SjjsbBIE=",
+        "owner": "Ef55",
+        "repo": "SpecMerger",
+        "rev": "38ac474cca1788ec4fb4d85ecaaa8c81aecf41f6",
+        "type": "github"
+      },
+      "original": {
+        "dir": ".nix",
+        "owner": "Ef55",
+        "repo": "SpecMerger",
+        "rev": "38ac474cca1788ec4fb4d85ecaaa8c81aecf41f6",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
Bump python version used in the flake (`3.11` -> `3.13`) for compatibility with the flake update in epfl-systemf/warblre#6